### PR TITLE
Update privacy ssh client

### DIFF
--- a/guide/system/privacy.md
+++ b/guide/system/privacy.md
@@ -382,6 +382,7 @@ To enable Tor in the background follow the same instructions for the [preparatio
     User admin
     Port 22
     CheckHostIP no
+    VerifyHostKeyDNS no
     ProxyCommand /usr/bin/nc -x localhost:9050 %h %p
   ```
 


### PR DESCRIPTION
#### What

VerifyHostKeyDNS no is there to avoid a DNS leak. 

#### Why

This is the default anyway, but DNS leaking is bad and you should make sure.