### PR TITLE
Explicit creation of legacy wallet in bitcoin core

### DIFF
--- a/guide/bonus/bitcoin/electrum-personal-server.md
+++ b/guide/bonus/bitcoin/electrum-personal-server.md
@@ -142,7 +142,7 @@ eps needs a "dummy" wallet configured in bitcoind to correctly scan for transact
 Create a basic wallet with
 
   ```sh
-  $ bitcoin-cli createwallet "default" "true" "true" "" "true"
+  $ bitcoin-cli createwallet "default" "true" "true" "" "true" "false"
   ```
 
 and then add directive to autoload it into `bitcoin.conf`:


### PR DESCRIPTION
Newer versions of bitcoin core deprecated legacy wallet, and the createwallet command will now create a native wallet instead. EPS does not support it, so we need to add `"false"` as a parameter at the end to force a legacy wallet. This will only work until core allows legacy wallets at all, since EPS will not get updated anymore to support native wallets.

#### What

What is the reason for this change?

#### Why

Why is this change important?

#### How

How was this change accomplished?

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

#### Animated GIF (optional)

Add some snazz if you feel like it :)
