### PR TITLE
Update sparrow-server.md

### DIFF
--- a/bonus/bitcoin/sparrow-server.md
+++ b/bonus/bitcoin/sparrow-server.md
@@ -96,17 +96,19 @@ Expected output:
 *   Move data files to the home "admin" user
 
     ```sh
-    $ sudo mv Sparrow /home/admin/
+    $ sudo cp -r Sparrow /home/admin/
     ```
+{% hint style="info" %}
+If you come to update this is the final step
+{% endhint %}
+    
 *   Add the Sparrow executable to your PATH by creating a symlink to it within `/usr/local/bin`, which is already part of PATH.
 
     ```sh
     $ sudo ln -s /home/admin/Sparrow/bin/Sparrow /usr/local/bin/Sparrow
     ```
 
-{% hint style="info" %}
-If you come to update this is the final step
-{% endhint %}
+
 
 ### Run Sparrow
 

--- a/bonus/bitcoin/sparrow-server.md
+++ b/bonus/bitcoin/sparrow-server.md
@@ -98,8 +98,15 @@ Expected output:
     ```sh
     $ sudo cp -r Sparrow /home/admin/
     ```
+
+* Clean the remaining installation files from the "tmp" folder to avoid problems for the next update
+
+     ```sh
+     $ sudo rm -r Sparrow && rm sparrow-server-$VERSION-x86_64.tar.gz
+     ```
+
 {% hint style="info" %}
-If you come to update this is the final step
+If you come to update this is the final step, check the correct update by entering `$ Sparrow --version` command and skipping the next step, and jumping directly to the [Run Sparrow](sparrow-server.md#run-sparrow) section to start Sparrow server again with the new version.
 {% endhint %}
     
 *   Add the Sparrow executable to your PATH by creating a symlink to it within `/usr/local/bin`, which is already part of PATH.
@@ -107,8 +114,18 @@ If you come to update this is the final step
     ```sh
     $ sudo ln -s /home/admin/Sparrow/bin/Sparrow /usr/local/bin/Sparrow
     ```
+    
+*   Check the correct installation by reclaiming the version output
 
+    ```sh
+    $ Sparrow --version
+    ```
 
+**Example** of expected output:
+
+```
+> Sparrow Wallet 1.7.6
+```
 
 ### Run Sparrow
 


### PR DESCRIPTION
mv command only works first time but not on upgrade.

mv works only on first install. 
changed to cp to avoid error:
"cannot move 'Sparrow' to 'home/admin/Sparrow': Directory not empty."

