### PR TITLE
Update security.md

### DIFF
--- a/bitcoin/bitcoin/bitcoin-client.md
+++ b/bitcoin/bitcoin/bitcoin-client.md
@@ -41,7 +41,7 @@ cd /tmp
 * Set a temporary version environment variable to the installation
 
 ```sh
-VERSION=28.0
+VERSION=28.1
 ```
 
 * Get the latest binaries and signatures

--- a/index-1/security.md
+++ b/index-1/security.md
@@ -166,7 +166,7 @@ sudo apt update && sudo apt full-upgrade
 * Install Ngnix. Press "**y**" and `enter` or directly `enter` when the prompt asks you
 
 ```sh
-sudo apt install nginx
+sudo apt install nginx nginx-extras
 ```
 
 * Check the correct installation


### PR DESCRIPTION
#### What

To avoid error when you test barebone Nginx configuration

#### Why

If you do not install nginx-extras as well, you may get an error when test barebone Nginx configuration