### PR TITLE
Fix nginx stream module support

### DIFF
--- a/index-1/security.md
+++ b/index-1/security.md
@@ -166,7 +166,7 @@ sudo apt update && sudo apt full-upgrade
 * Install Ngnix. Press "**y**" and `enter` or directly `enter` when the prompt asks you
 
 ```sh
-sudo apt install nginx
+sudo apt install nginx-full
 ```
 
 * Check the correct installation


### PR DESCRIPTION
Fix nginx stream module support
Updated installation command to use `nginx-full` package instead of `nginx`, ensuring the stream module is available and properly configured.

#### What

This change updates the nginx installation command to use the `nginx-full` package instead of the default nginx meta-package.

#### Why

The default nginx package does not include support for the stream module. This caused nginx to fail on startup with an "unknown directive 'stream'" error.

#### How

Replaced `sudo apt install nginx` with `sudo apt install nginx-full` to ensure all required modules (including `stream`) are available.

#### Scope

- [**X**] simple bug fix

#### Test & maintenance

The fix can be tested by running `nginx -t` after installation to verify that the configuration is valid and the stream directive is now recognized.

No ongoing maintenance is expected, as `nginx-full` is a stable package maintained by the Debian/Ubuntu maintainers.

This is a one-time fix and does not require future updates unless the package naming or module availability changes in future distro versions.
