### PR TITLE
Update PostgreSQL guide to include user permissions

### DIFF
--- a/bonus-guides/system/postgresql.md
+++ b/bonus-guides/system/postgresql.md
@@ -143,6 +143,12 @@ sudo mkdir -p /data/postgresdb/18
 <pre class="language-bash"><code class="lang-bash"><strong>sudo chmod -R 700 /data/postgresdb
 </strong></code></pre>
 
+* Add user postgres to the bitcoin group so it can access the data folder
+
+```bash
+sudo usermod -aG bitcoin postgres
+```
+
 * With user `postgres`, create a new cluster in the dedicated folder
 
 ```bash


### PR DESCRIPTION
#### What

When trying to execute:
sudo -u postgres /usr/lib/postgresql/18/bin/initdb -D /data/postgresdb/18 I got this error:
initdb: error: could not access directory "/data/postgresdb/18": Permission denied because user postgres does not have access to /data folder

#### Why

To avoid getting errors following the guide

#### How

Added one instruction to add user postgres to bitcoin group so that it can access /data folder

#### Scope

- [ ] significant change to core configuration
- [x ] independent bonus guide
- [ ] simple bug fix

Fixes # (link issue)

#### Test & maintenance

How can the changes be tested? Is there ongoing maintenance effort? If this is a bonus guide: are you willing to update it from time to time?

#### Animated GIF (optional)

Add some snazz if you feel like it :)
